### PR TITLE
Move logic into log class

### DIFF
--- a/src/Coordinator.java
+++ b/src/Coordinator.java
@@ -143,10 +143,8 @@ public class Coordinator {
 
         try {
 
-            if(this.coordinatorLog.readLogBottom().split(" ")[0].equals("COMMIT") ||
-                    this.coordinatorLog.readLogBottom().split(" ")[0].equals("ABORT")) {
-
-
+            if (this.coordinatorLog.isLatestMsg("COMMIT") ||
+                    this.coordinatorLog.isLatestMsg("ABORT")) {
 
                 Printer.print("\n=============== COORDINATOR RESURRECTS =================", "red");
 
@@ -154,9 +152,9 @@ public class Coordinator {
 
                 int numberOfPreviouslyCrashedSubordinates;
 
-                if(!this.failedSubordinatesLog.readLogBottom().isEmpty()) {
+                if (!this.failedSubordinatesLog.isEmpty()) {
 
-                    numberOfPreviouslyCrashedSubordinates = Integer.parseInt(this.failedSubordinatesLog.readLogBottom());
+                    numberOfPreviouslyCrashedSubordinates = Integer.parseInt(this.failedSubordinatesLog.readBottom());
 
                 } else {
 
@@ -171,8 +169,7 @@ public class Coordinator {
 
                 }
 
-                int temp = this.maxSubordinates;
-                this.maxSubordinates = temp - numberOfPreviouslyCrashedSubordinates;
+                this.maxSubordinates -= numberOfPreviouslyCrashedSubordinates;
 
                 Printer.print("\nWaiting for " + maxSubordinates + " subordinate(s) to reconnect...\n", "white");
 
@@ -441,7 +438,7 @@ public class Coordinator {
          */
         this.reAcceptCrashedSubordinates(crashedSubordinateIndices);
 
-        if (this.loggedDecision.isEmpty()) this.loggedDecision = coordinatorLog.readLogBottom().split(" ")[0];
+        if (this.loggedDecision.isEmpty()) this.loggedDecision = coordinatorLog.getLatestMsg();
 
         boolean decisionMsgPrinted = false;
         List<Integer> unreachableSubordinatesIndices = new ArrayList<>();

--- a/src/Logger.java
+++ b/src/Logger.java
@@ -70,10 +70,28 @@ public class Logger {
 
     }
 
-    public String readLogBottom() {
+    public String readBottom() {
 
         if (this.reverseLog.isEmpty()) return "";
         return this.reverseLog.peek();
+
+    }
+
+    public String getLatestMsg() {
+
+        return this.readBottom().split(" ")[0];
+
+    }
+
+    public boolean isLatestMsg(String msg) {
+
+        return this.getLatestMsg().equals(msg);
+
+    }
+
+    public boolean isEmpty() {
+
+        return this.readBottom().isEmpty();
 
     }
 

--- a/src/Subordinate.java
+++ b/src/Subordinate.java
@@ -67,7 +67,7 @@ public class Subordinate {
 
         System.out.println("\nMy coordinator (C) is @ port " + this.coordinatorSocket.getPort() + "\n\n");
 
-        String loggedDecision = this.SubordinateLog.readLogBottom().split(" ")[0];
+        String loggedDecision = this.SubordinateLog.getLatestMsg();
 
         if(loggedDecision.equals("ABORT") || loggedDecision.equals("PREPARED") || loggedDecision.equals("COMMIT")) {
 
@@ -190,7 +190,7 @@ public class Subordinate {
         Printer.print("Waiting for the coordinator's decision message...\n", "white");
 
         String decisionMsg = "";
-        this.loggedVote = this.SubordinateLog.readLogBottom().split(" ")[0];
+        this.loggedVote = this.SubordinateLog.getLatestMsg();
         boolean reconnectSuccess = true;
         boolean reEnterPhaseOne = false;
 
@@ -236,7 +236,7 @@ public class Subordinate {
 
             Printer.print("\nCoordinator is considered crashed permanently!", "red");
 
-            if(!this.SubordinateLog.readLogBottom().split(" ")[0].equals("ABORT")){
+            if (!this.SubordinateLog.isLatestMsg("ABORT")) {
 
                 this.SubordinateLog.log("ABORT", true, true, true);
 
@@ -260,8 +260,8 @@ public class Subordinate {
                     case "COMMIT":
                     case "ABORT":
 
-                        if (!this.SubordinateLog.readLogBottom().split(" ")[0].equals("ABORT") &&
-                                !this.SubordinateLog.readLogBottom().split(" ")[0].equals("COMMIT")) {
+                        if (!this.SubordinateLog.isLatestMsg("ABORT") &&
+                                !this.SubordinateLog.isLatestMsg("COMMIT")) {
 
                             this.SubordinateLog.log(decisionMsg, true, true, true);
 


### PR DESCRIPTION
* `Logger.readLogBottom()` contains redundant *log*
  + renamed to `readBottom()`
* Caller has too much responsibility: `Logger.readLogBottom().split(" ")[0].equals("ABORT")`
  + introduced `boolean isLatestMsg(String msg)`
  + introduced `String getLatestMsg()`