### PR TITLE
Simplify log() by using default params

### DIFF
--- a/src/Coordinator.java
+++ b/src/Coordinator.java
@@ -285,17 +285,17 @@ public class Coordinator {
 
             if (decision) {
 
-                this.coordinatorLog.log("COMMIT", true, true, true);
+                this.coordinatorLog.log("COMMIT", true);
 
             } else {
 
-                this.coordinatorLog.log("ABORT", true, true, true);
+                this.coordinatorLog.log("ABORT", true);
 
             }
 
             if(this.sockets.size() == 0) {
 
-                this.coordinatorLog.log("END", false, true, true);
+                this.coordinatorLog.log("END");
                 this.failedSubordinatesLog.emptyLog();
 
             }
@@ -415,7 +415,7 @@ public class Coordinator {
 
         } else {
 
-            this.coordinatorLog.log("END", false, true, true);
+            this.coordinatorLog.log("END");
 
             if (this.isRecoveryProcessStarted)
                 Printer.print("=============== END OF RECOVERY PROCESS =================\n", "orange");

--- a/src/Logger.java
+++ b/src/Logger.java
@@ -42,16 +42,27 @@ public class Logger {
 
     }
 
+    public void log(String msg) throws IOException {
+        log(msg, false, true, true);
+    }
+
+    public void log(String msg, boolean forceWrite) throws IOException {
+        log(msg, forceWrite, true, true);
+    }
+
+    public void log(String msg, boolean forceWrite, boolean appendDate) throws IOException {
+        log(msg, forceWrite, appendDate, true);
+    }
+
     public void log(String msg, boolean forceWrite, boolean appendDate, boolean verbose) throws IOException {
-        String newLogEntry;
+        String newLogEntry = msg;
 
         if(appendDate) {
-            String timeStamp  = dateFormat.format(new Date());
-            newLogEntry = msg + " " + timeStamp + "\n";
-        } else {
-            newLogEntry = msg + "\n";
+            String timeStamp = dateFormat.format(new Date());
+            newLogEntry += " " + timeStamp;
         }
 
+        newLogEntry += "\n";
 
         this.bw.write(newLogEntry);
         this.bw.flush();

--- a/src/Subordinate.java
+++ b/src/Subordinate.java
@@ -142,7 +142,7 @@ public class Subordinate {
                         inputHandler.getUserInput().toUpperCase().equals("Y") &&
                         ((System.currentTimeMillis() - startTime) < Coordinator.TIMEOUT_MILLIS))  {
 
-                    this.SubordinateLog.log("PREPARED", true, true, true);
+                    this.SubordinateLog.log("PREPARED", true);
                     this.send("Y");
                     Printer.print("=============== END OF PHASE 1 =================\n", "blue");
                     this.phaseTwo();
@@ -151,7 +151,7 @@ public class Subordinate {
                         inputHandler.getUserInput().toUpperCase().equals("N") &&
                         ((System.currentTimeMillis() - startTime) < Coordinator.TIMEOUT_MILLIS)) {
 
-                    this.SubordinateLog.log("ABORT", true, true, true);
+                    this.SubordinateLog.log("ABORT", true);
                     this.send("N");
                     Printer.print("=============== END OF PHASE 1 =================\n", "blue");
                     this.phaseTwo();
@@ -238,11 +238,11 @@ public class Subordinate {
 
             if(!this.SubordinateLog.readLogBottom().split(" ")[0].equals("ABORT")){
 
-                this.SubordinateLog.log("ABORT", true, true, true);
+                this.SubordinateLog.log("ABORT", true);
 
             }
 
-            this.SubordinateLog.log("END", false, true, true);
+            this.SubordinateLog.log("END");
 
             Printer.print("=============== END OF RECOVERY PROCESS =================", "orange");
             Printer.print("=============== UNILATERAL ABORT =================\n", "red");
@@ -263,7 +263,7 @@ public class Subordinate {
                         if (!this.SubordinateLog.readLogBottom().split(" ")[0].equals("ABORT") &&
                                 !this.SubordinateLog.readLogBottom().split(" ")[0].equals("COMMIT")) {
 
-                            this.SubordinateLog.log(decisionMsg, true, true, true);
+                            this.SubordinateLog.log(decisionMsg, true);
 
                         }
 
@@ -373,7 +373,7 @@ public class Subordinate {
                 (timeDiff < Coordinator.TIMEOUT_MILLIS)) {
 
             this.send("ACK");
-            this.SubordinateLog.log("END", false, true, true);
+            this.SubordinateLog.log("END");
             Printer.print("=============== END OF PHASE 2 =================\n", "green");
 
 


### PR DESCRIPTION
The default parameters are currently set to:

```java
log(String msg,                   // needed
    boolean forceWrite = false,   // force shouldn't be default
    boolean appendDate = true,    // most calls use this
    boolean verbose = true);      // most calls use this
```