### PR TITLE
Simplify print() by using default params

### DIFF
--- a/src/Coordinator.java
+++ b/src/Coordinator.java
@@ -174,7 +174,7 @@ public class Coordinator {
                 int temp = this.maxSubordinates;
                 this.maxSubordinates = temp - numberOfPreviouslyCrashedSubordinates;
 
-                Printer.print("\nWaiting for " + maxSubordinates + " subordinate(s) to reconnect...\n", "white");
+                Printer.print("\nWaiting for " + maxSubordinates + " subordinate(s) to reconnect...\n");
 
                 this.acceptSubordinates();
 
@@ -182,7 +182,7 @@ public class Coordinator {
 
             } else {
 
-                Printer.print("\nWaiting for " + maxSubordinates + " subordinate(s) to connect...\n", "white");
+                Printer.print("\nWaiting for " + maxSubordinates + " subordinate(s) to connect...\n");
 
                 this.acceptSubordinates();
 
@@ -228,8 +228,7 @@ public class Coordinator {
 
             } else {
 
-                Printer.print("", "");
-                Printer.print("=============== COORDINATOR CRASHES =================\n", "red");
+                Printer.print("\n=============== COORDINATOR CRASHES =================\n", "red");
 
             }
 
@@ -341,7 +340,7 @@ public class Coordinator {
                 inputHandler.getUserInput().toUpperCase().equals("") &&
                 (timeDiff < Coordinator.TIMEOUT_MILLIS)) {
 
-            Printer.print("", "white");
+            Printer.print("");
 
             this.broadcast(decisionMessage);
 
@@ -455,14 +454,14 @@ public class Coordinator {
                 case "COMMIT":
                 case "ABORT":
 
-                    if (!decisionMsgPrinted) Printer.print("\nMessage sent to previously crashed subordinate(s): " + loggedDecision, "white");
+                    if (!decisionMsgPrinted) Printer.print("\nMessage sent to previously crashed subordinate(s): " + loggedDecision);
                     decisionMsgPrinted = true;
 
                     break;
 
                 case "":
 
-                    if (!decisionMsgPrinted) Printer.print("Message sent to crashed subordinate(s): ABORT", "white");
+                    if (!decisionMsgPrinted) Printer.print("Message sent to crashed subordinate(s): ABORT");
                     decisionMsgPrinted = true;
 
                     break;
@@ -488,7 +487,7 @@ public class Coordinator {
 
         if(unreachableSubordinatesIndices.size() > 0) this.recoveryProcess(unreachableSubordinatesIndices);
 
-        Printer.print("", "white");
+        Printer.print("");
 
         if(reachableSubordinatesIndices.size() > 0) this.checkAcknowledgements(reachableSubordinatesIndices);
 
@@ -505,7 +504,7 @@ public class Coordinator {
 
         this.serverSocket = new ServerSocket(SERVER_SOCKET_PORT);
 
-        Printer.print("\nWaiting for crashed subordinates to reconnect...\n", "white");
+        Printer.print("\nWaiting for crashed subordinates to reconnect...\n");
 
         int numberOfReconnectedSubordinates = 0;
 

--- a/src/CoordinatorReceiver.java
+++ b/src/CoordinatorReceiver.java
@@ -35,22 +35,22 @@ public class CoordinatorReceiver implements Runnable {
         switch (this.receivedMessage) {
 
             case ("Y"): {
-                Printer.print("S" + this.subordinateIndex + ": " + "\"YES\"", "white");
+                Printer.print("S" + this.subordinateIndex + ": " + "\"YES\"");
                 break;
             }
 
             case ("N"): {
-                Printer.print("S" + this.subordinateIndex + ": " + "\"NO\"", "white");
+                Printer.print("S" + this.subordinateIndex + ": " + "\"NO\"");
                 break;
             }
 
             case(""): {
-                Printer.print("S" + this.subordinateIndex + ": " + "[No message received]", "white");
+                Printer.print("S" + this.subordinateIndex + ": " + "[No message received]");
                 break;
             }
 
             default: {
-                Printer.print("S" + this.subordinateIndex + ": " + "\"" + this.receivedMessage + "\"", "white");
+                Printer.print("S" + this.subordinateIndex + ": " + "\"" + this.receivedMessage + "\"");
                 break;
             }
 

--- a/src/Printer.java
+++ b/src/Printer.java
@@ -1,27 +1,30 @@
+import java.util.HashMap;
+import java.util.Map;
+
 public class Printer {
 
-    private static final String RED = "\033[0;31m";
-    private static final String GREEN = "\033[0;32m";
-    private static final String ORANGE = "\033[0;33m";
-    private static final String BLUE = "\033[0;34m";
-    private static final String NO_COLOR = "\033[0m";
+    private static final Map<String, String> COLORS = createMap();
+    private static final String RESET_COLOR = "\033[0m";
 
-    public static void print(String msg, String colour){
-        switch (colour) {
-            case "red":
-                System.out.println(RED + msg + NO_COLOR);
-                break;
-            case "green":
-                System.out.println(GREEN + msg + NO_COLOR);
-                break;
-            case "orange":
-                System.out.println(ORANGE + msg + NO_COLOR);
-                break;
-            case "blue":
-                System.out.println(BLUE + msg + NO_COLOR);
-                break;
-            default:
-                System.out.println(msg);
-        }
+    private static Map<String, String> createMap() {
+        Map<String, String> c = new HashMap<>();
+        c.put("red", "\033[0;31m");
+        c.put("green", "\033[0;32m");
+        c.put("orange", "\033[0;33m");
+        c.put("blue", "\033[0;34m");
+        return c;
     }
+
+    public static void print(String msg) {
+        System.out.println(msg);
+    }
+
+    public static void print(String msg, String color) {
+        String colorEscape = COLORS.get(color);
+        if (colorEscape == null)
+            print(msg);
+        else
+            System.out.println(COLORS.get(color) + msg + RESET_COLOR);
+    }
+
 }

--- a/src/Subordinate.java
+++ b/src/Subordinate.java
@@ -97,7 +97,7 @@ public class Subordinate {
 
         } catch (NullPointerException ste) {
 
-            Printer.print("C: [No \"PREPARE\"-message received from coordinator]", "white]");
+            Printer.print("C: [No \"PREPARE\"-message received from coordinator]");
             Printer.print("\n=============== SUBORDINATE CRASHES =================\n", "red");
 
         }
@@ -109,7 +109,7 @@ public class Subordinate {
 
             if(this.recoveryProcessStarted) {
 
-                Printer.print("Subordinate-log reads: \"" + this.loggedVote + "\"", "white");
+                Printer.print("Subordinate-log reads: \"" + this.loggedVote + "\"");
 
                 this.sendVote();
 
@@ -187,7 +187,7 @@ public class Subordinate {
     private void phaseTwo() throws IOException {
 
         Printer.print("\n=============== START OF PHASE 2 ===============", "green");
-        Printer.print("Waiting for the coordinator's decision message...\n", "white");
+        Printer.print("Waiting for the coordinator's decision message...\n");
 
         String decisionMsg = "";
         this.loggedVote = this.SubordinateLog.readLogBottom().split(" ")[0];
@@ -315,14 +315,14 @@ public class Subordinate {
 
             try {
 
-                Printer.print("Reconnecting to coordinator...\n", "white");
+                Printer.print("Reconnecting to coordinator...\n");
 
                 this.coordinatorSocket = new Socket(Coordinator.SERVER_SOCKET_HOST, Coordinator.SERVER_SOCKET_PORT);
                 this.coordinatorSocket.setSoTimeout(0);
                 this.reader = new BufferedReader(new InputStreamReader(this.coordinatorSocket.getInputStream(), StandardCharsets.UTF_8));
                 this.writer = new OutputStreamWriter(this.coordinatorSocket.getOutputStream(), StandardCharsets.UTF_8);
 
-                Printer.print("Successfully reconnected to coordinator!\n", "white");
+                Printer.print("Successfully reconnected to coordinator!\n");
                 return true;
 
             } catch (ConnectException ce) {
@@ -392,7 +392,7 @@ public class Subordinate {
     private void resurrect(String loggedDecision) throws IOException {
 
         Printer.print("=============== SUBORDINATE RESURRECTS =================\n", "red");
-        Printer.print("Subordinate-log reads: \"" + loggedDecision + "\"", "white");
+        Printer.print("Subordinate-log reads: \"" + loggedDecision + "\"");
         Printer.print("Re-entering phase 2...", "green");
 
         this.phaseTwo();


### PR DESCRIPTION
Add default color parameter to `Printer.print()`, so that

```java
Printer.print("foo", "red");
Printer.print("bar", "white");
Printer.print("baz", "");
```

can be reduced to

```java
Printer.print("foo", "red");
Printer.print("bar");
Printer.print("baz");
```

Also, the color `"white"` was not explicitly defined.